### PR TITLE
Fix Docker Readme Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ source /opt/openoni/ENV/bin/activate
 django-admin.py load_batch /batches/prefix_batchname/batch_prefix_name_ver01
 ```
 
-If you are using docker development environment, please see the [docker](https://github.com/open-oni/docker-open-oni) repo for instructions for loading a batch when using docker containers.
+If you are using docker development environment, please see the [docker](https://github.com/open-oni/open-oni/blob/master/docker/README.md) readme for instructions for loading a batch when using docker containers.
 
 ### Batch Description
 


### PR DESCRIPTION
Pointing to https://github.com/open-oni/open-oni/blob/master/docker/README.md instead of the deprecated docker repo
